### PR TITLE
ArchUnitのガイドを最新化（英語）

### DIFF
--- a/en/java/staticanalysis/archunit/docs/ArchUnit-commentary.md
+++ b/en/java/staticanalysis/archunit/docs/ArchUnit-commentary.md
@@ -28,11 +28,9 @@ ArchRuleDefinition.classes().that().haveSimpleNameEndingWith("Action").should().
 
 If this check is done and the class name ends in `Action` but it is a package private,  in violation.
 
-By the way, if the above content is a test that can be executed by JUnit4, it would look like the following.
+By the way, if the above content is a test that can be executed by JUnit 5, it would look like the following.
 
 ```java
- 
-@RunWith(ArchUnitRunner.class)
 @AnalyzeClasses(packages = "com.nablarch.example.proman")
 public class ActionRuleTest {
 
@@ -82,7 +80,7 @@ Here are three frequently used checks, along with some code examples.
 
 The declaration check involves checking classes, methods, field qualifiers, types, etc.
 
-For example, the following example checks that the `DaoContext` field is private and final, but not static.
+For example, the following example checks that field of type `DaoContext` are private and final, and not static.
 
 It should be noted that if the qualifier does not have to be given at the time of declaration, it should include a check "not xx". (The following example checks that it is not static.)
 
@@ -90,7 +88,8 @@ It should be noted that if the qualifier does not have to be given at the time o
 ArchRuleDefinition.fields().that().haveRawType(DaoContext.class)
                 .should().bePrivate()
                 .andShould().beFinal()
-                .andShould().notBeStatic();
+                .andShould().notBeStatic()
+                .allowEmptyShould(true);
 ```
 
 In the following example, if the class name ends in Action, we check that it extends BatchAction.
@@ -139,6 +138,7 @@ Only the action package can depend on other packages, and the dependency on its 
 
 ```java
 Architectures.layeredArchitecture()
+    .consideringAllDependencies()
     .layer("Action").definedBy("..action..")
     .layer("Service").definedBy("..service..")
     .layer("Form").definedBy("..form..")

--- a/en/java/staticanalysis/archunit/docs/Maven-settings.md
+++ b/en/java/staticanalysis/archunit/docs/Maven-settings.md
@@ -6,19 +6,15 @@ ArchUnit can be run as a JUnit test by running the `mvn test`.
 
 ## Include ArchUnit dependencies
 
-Edit the `pom.xml`.
-
-The place to add the configuration is directly under the `dependencies` element.
+Edit `pom.xml` to add ArchUnit as a dependency.
 
 ```xml
-  <dependencies>
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit4</artifactId>
-      <version>0.13.1</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+<dependency>
+    <groupId>com.tngtech.archunit</groupId>
+    <artifactId>archunit-junit5</artifactId>
+    <version>1.0.1</version>
+    <scope>test</scope>
+</dependency>
 ```
 
 ## Running tests with Maven
@@ -32,10 +28,13 @@ mvn test
 If there is a violation, the test and the target of the violation will be output as follows.
 
 ```
-[ERROR] Failures:
-[ERROR]   ServiceClassRuleTest.DaoContextをfieldに持つ場合private_finalであるがstaticじゃないこと Architecture Violation [Priority: MEDIUM] - Rule 'fields that have raw type nablarch.common.dao.DaoContext and are declared in classes that have simple name ending with 'Service' should be final and should not be private and should be static' was violated (2 times):
-Field <com.nablarch.example.proman.web.project.ProjectService.universalDao> does not have modifier STATIC in (ProjectService.java:0)
-Field <com.nablarch.example.proman.web.project.ProjectService.universalDao> has modifier PRIVATE in (ProjectService.java:0)
+[ERROR] ExampleRuleTest.Actionがpublicであること  Time elapsed: 0.409 s  <<< FAILURE!
+java.lang.AssertionError: 
+Architecture Violation [Priority: MEDIUM] - Rule 'classes that have simple name ending with 'Action' should be public' was violated (1 times):
+Class <com.example.ExampleAction> does not have modifier PUBLIC in (ExampleAction.java:0)
+	at com.tngtech.archunit.lang.ArchRule$Assertions.assertNoViolation(ArchRule.java:94)
+	at com.tngtech.archunit.lang.ArchRule$Assertions.check(ArchRule.java:86)
+	...
 ```
 
 If you pass all the tests, the output as follows.

--- a/en/java/staticanalysis/archunit/docs/Ops-Rule.md
+++ b/en/java/staticanalysis/archunit/docs/Ops-Rule.md
@@ -64,10 +64,6 @@ After specifying the test target, additional conditions can be specified by usin
 
 By specifying the class name in the `doNotBelongToAnyOf` method, you can exclude the target class and its internally defined classes from being tested.
 
-By specifying class name in the `doNotBelongToAnyOf` method, you can exclude the class in question and classes defined within the class in question from being tested.
-
-If the test target is a class (including layers), then the argument to `and()` (or `that()` if there is no `that()` to begin with) is `DescribedPredicate.not(JavaClass.Predicates.belongToAnyOf(Excluded Exclude classes 1, 2, and so on...)]` to set up the exclusion.
-
 ``` java
 @ArchTest
 public static final ArchRule actionClassMustInheritFromBatchAction. =

--- a/en/java/staticanalysis/archunit/docs/Ops-Rule.md
+++ b/en/java/staticanalysis/archunit/docs/Ops-Rule.md
@@ -73,7 +73,7 @@ If the test target is a class (including layers), then the argument to `and()` (
 public static final ArchRule actionClassMustInheritFromBatchAction. =
         ArchRuleDefinition.classes()
         .that().haveSimpleNameEndingWith("Action")
-        .and().doNotBelongToAnyOf(PromanExampleAction.class, PromanServiceAction.class)  // #12345,12346
+        .and().doNotBelongToAnyOf(PromanExampleAction.class, PromanServiceAction.class) // #12345,12346
         .should().beAssignableTo(BatchAction.class);
 ```
 

--- a/en/java/staticanalysis/archunit/docs/Ops-Rule.md
+++ b/en/java/staticanalysis/archunit/docs/Ops-Rule.md
@@ -53,42 +53,46 @@ There are two main methods to exclude architecture violations from testing.
 - Describe the exclusion target in the test code.
 - Describe in the exclusion configuration file and exclude it from all architecture tests.
 
-Note that the former is described differently depending on the subject of the test.
+If make an exclusion setting, can follow the history later by doing the following.
 
-### Configuration of the exclusion target class (the exclusion target is described in the test code)
+- Describe the issue management system's issue management number in the comments of the source code.
+- Include in the commit comments in the version control system.
+
+### Configuration of the exclusion target class (Describe the exclusion target in the test code)
+
+After specifying the test target, additional conditions can be specified by using the `and` method.
+
+By specifying the class name in the `doNotBelongToAnyOf` method, you can exclude the target class and its internally defined classes from being tested.
+
+By specifying class name in the `doNotBelongToAnyOf` method, you can exclude the class in question and classes defined within the class in question from being tested.
 
 If the test target is a class (including layers), then the argument to `and()` (or `that()` if there is no `that()` to begin with) is `DescribedPredicate.not(JavaClass.Predicates.belongToAnyOf(Excluded Exclude classes 1, 2, and so on...)]` to set up the exclusion.
 
 ``` java
 @ArchTest
 public static final ArchRule actionClassMustInheritFromBatchAction. =
-        ArchRuleDefinition.classes().that().haveSimpleNameEndingWith("Action")
-        .and(DescribedPredicate.not(
-                JavaClass.Predicates.belongToAnyOf(
-                  PromanExampleAction.class, // #12345
-                  PromanServiceAction.class  // #12346
-                )
-        )).should().beAssignableTo(BatchAction.class);
+        ArchRuleDefinition.classes()
+        .that().haveSimpleNameEndingWith("Action")
+        .and().doNotBelongToAnyOf(PromanExampleAction.class, PromanServiceAction.class)  // #12345,12346
+        .should().beAssignableTo(BatchAction.class);
 ```
 
-If the test target is contained in a class, such as a field or a method, the `areNotDeclaredIn()` is used to set the exclusion.
+To exclude fields, methods, etc. defined within a specific class, you can use the `areNotDeclaredIn` method.
 
 ``` java
 @ArchTest
 public static final ArchRule methodsThatTakeDaoContextAsAnArgumentMustBePackagePrivate =
-        ArchRuleDefinition.methods().that().haveRawParameterTypes(DaoContext.class)
-            .and().areNotDeclaredIn(PromanExamAction.class)  // #1234
-            .should().bePackagePrivate();
+        ArchRuleDefinition.methods()
+        .that().haveRawParameterTypes(DaoContext.class)
+        .and().areNotDeclaredIn(PromanExamAction.class) // #1234
+        .should().bePackagePrivate();
 ```
 
-If make an exclusion setting, can follow the history later by doing the following.
+### Configuring of the exclusion package (Describe the exclusion target in the test code)
 
-- Describe the issue management system's issue management number in the comments of the source code.
-- Include in the commit comments in the version control system.
+You can exclude target packages from testing by specifying them in the `resideOutsideOfPackage` method.
+However, you should consider the package structure beforehand, as packages are subject to specific strings.
 
-### Configuring the exclusion package (specifying the exclusion target in the test code)
-
-If test targets are classes, can exclude certain packages in the following way.
 In the following example, exclude packages containing `common`.
 
 ```java
@@ -99,14 +103,14 @@ public  static  final ArchRule noClassesUsingNoDataExceptionInNonInstrumentalPac
         .should().dependOnClassesThat().areAssignableTo(NoDataException.class);
 ```
 
-However, you should consider the package structure beforehand, as packages are subject to specific strings.
+If you want to test only a specific package, you can use the `resideInAPackage` method.
 
-### Exclusions by custom rules (to list the exclusions in the test code)
+### Exclusions by custom rules (Describe the exclusion target in the test code)
 
 Custom rules can be implemented to allow for more granular exclusions.
 Refer to the [ArchUnit User Guide](https://www.archunit.org/userguide/html/000_Index.html#_creating_custom_rules) for more information.
 
-### Exclude it from all architecture tests by including it in the exclusion configuration file
+### Describe in the exclusion configuration file and exclude it from all architecture tests.
 
 Create the `archunit_ignore_patterns.txt` under `src/test/resources` of the module for architecture testing, and write regular expressions to exclude them.
 Can ignore violations of class `some.pkg.LegacyService` by writing the following.
@@ -116,10 +120,7 @@ Can ignore violations of class `some.pkg.LegacyService` by writing the following
 .*some\.pkg\.LegacyService.*
 ```
 
-Can include comments by adding a `#` so that you can track the history later if you do the following.
-
-- Describe the issue management system's issue management number in the comments of the configuration file.
-- Include in the commit comments in the version control system.
+In the file, you can include comments by prefixing them with `#`.
 
 #### Note
 

--- a/java/staticanalysis/archunit/docs/Ops-Rule.md
+++ b/java/staticanalysis/archunit/docs/Ops-Rule.md
@@ -69,7 +69,7 @@ ArchUnitではクラスパス・モジュールパスに含まれるクラスか
 public static final ArchRule ActionクラスはBatchActionを継承していること =
         ArchRuleDefinition.classes()
         .that().haveSimpleNameEndingWith("Action")
-        .and().doNotBelongToAnyOf(PromanExampleAction.class, PromanServiceAction.class)
+        .and().doNotBelongToAnyOf(PromanExampleAction.class, PromanServiceAction.class) // #12345,12346
         .should().beAssignableTo(BatchAction.class);
 ```
 
@@ -80,7 +80,7 @@ public static final ArchRule ActionクラスはBatchActionを継承している�
 public static final ArchRule DaoContextを引数にとるメソッドはパッケージプライベートであること =
         ArchRuleDefinition.methods()
         .that().haveRawParameterTypes(DaoContext.class)
-        .and().areNotDeclaredIn(PromanExamAction.class)
+        .and().areNotDeclaredIn(PromanExamAction.class) // #1234
         .should().bePackagePrivate();
 ```
 


### PR DESCRIPTION
日本語版のコードサンプルから課題番号のソースコメントを誤って削除してしまっていたので、合わせて修正しました。