### PR TITLE
SpotBugsガイドをJava17に対応

### DIFF
--- a/en/java/staticanalysis/spotbugs/docs/Maven-settings.md
+++ b/en/java/staticanalysis/spotbugs/docs/Maven-settings.md
@@ -83,7 +83,7 @@ If there is a check violation, the following points are output to the console:
 [INFO] BugInstance size is 1
 [INFO] Error size is 0
 [INFO] Total bugs: 1
-[ERROR] Medium: String オブジェクトを == や != を使用して比較しています。com.example.ComparingStringsWithEq.example() [com.example.ComparingStringsWithEq] 該当箇所 ComparingStringsWithEq.java:[line 11] ES_COMPARING_STRINGS_WITH_EQ
+[ERROR] Medium: Comparison of String objects using == or != in com.example.ComparingStringsWithEq.example() [com.example.ComparingStringsWithEq] At ComparingStringsWithEq.java:[line 11] ES_COMPARING_STRINGS_WITH_EQ
 ```
 
 If all checks are passed, they are output to the console as follows:

--- a/en/java/staticanalysis/spotbugs/docs/Maven-settings.md
+++ b/en/java/staticanalysis/spotbugs/docs/Maven-settings.md
@@ -2,7 +2,7 @@
 
 This document will guide you how to configure and run SpotBugs with Maven.
 
-The contents of this document have been verified with Maven 3.6.3.
+The contents of this document have been verified with Maven 3.9.2.
 
 ## Deploy filter files to exclude checks
 
@@ -29,14 +29,7 @@ The location to add the configuration is directly under `build`, which is direct
 <plugin>
   <groupId>com.github.spotbugs</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
-  <version>4.5.0.0</version>
-  <dependencies>
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs</artifactId>
-      <version>4.5.0</version>
-    </dependency>
-  </dependencies>
+  <version>4.7.3.4</version>
   <configuration>
     <xmlOutput>true</xmlOutput>
     <!-- Filter file to exclude checks -->
@@ -87,17 +80,15 @@ mvn compile
 If there is a check violation, the following points are output to the console:
 
 ```
-[INFO] --- spotbugs-maven-plugin:4.5.0.0:check (default-cli) @ spotbugs-example ---
 [INFO] BugInstance size is 1
 [INFO] Error size is 0
 [INFO] Total bugs: 1
-[INFO] String objects are compared using == and !=. com.example.App.main(String[]) [com.example.App] applicable location App.java:[line 9] ES_COMPARING_STRINGS_WITH_EQ
+[ERROR] Medium: String オブジェクトを == や != を使用して比較しています。com.example.ComparingStringsWithEq.example() [com.example.ComparingStringsWithEq] 該当箇所 ComparingStringsWithEq.java:[line 11] ES_COMPARING_STRINGS_WITH_EQ
 ```
 
 If all checks are passed, they are output to the console as follows:
 
 ```
-[INFO] --- spotbugs-maven-plugin:4.5.0.0:check (default-cli) @ spotbugs-example ---
 [INFO] BugInstance size is 0
 [INFO] Error size is 0
 [INFO] No errors/warnings found

--- a/en/java/staticanalysis/spotbugs/docs/find-sec-bugs.md
+++ b/en/java/staticanalysis/spotbugs/docs/find-sec-bugs.md
@@ -13,7 +13,7 @@ Edit `pom.xml`.
 <plugin>
   <groupId>com.github.spotbugs</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
-  <version>4.5.0.0</version>
+  <version>4.7.3.4</version>
   <!-- omission  -->
   <configuration>
     <!-- omission  -->
@@ -27,7 +27,7 @@ Edit `pom.xml`.
       <plugin>
         <groupId>com.h3xstream.findsecbugs</groupId>
         <artifactId>findsecbugs-plugin</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.0</version>
       </plugin>
     </plugins>
   </configuration>

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/.gitignore
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/.gitignore
@@ -1,0 +1,26 @@
+/target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+.checkstyle
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/build/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
@@ -12,32 +12,16 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
-
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
 
   <build>
     <plugins>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.5.0.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs</artifactId>
-            <version>4.5.0</version>
-          </dependency>
-        </dependencies>
+        <version>4.7.3.4</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <!-- Filter file for removal of checking -->
@@ -55,7 +39,7 @@
             <plugin>
               <groupId>com.h3xstream.findsecbugs</groupId>
               <artifactId>findsecbugs-plugin</artifactId>
-              <version>1.11.0</version>
+              <version>1.12.0</version>
             </plugin>
           </plugins>
         </configuration>

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/spotbugs/published-config/production/ExampleOpenApi.config
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/spotbugs/published-config/production/ExampleOpenApi.config
@@ -1,9 +1,9 @@
-//Constructors are permitted
-com.example.ClassA.ClassA()
-com.example.ClassB.ClassB()
-com.example.ClassC.ClassC()
+// コンストラクタを許可する
+com.example.api.ClassA.ClassA()
+com.example.api.ClassB.ClassB()
+com.example.api.ClassC.ClassC()
 
-com.example.ClassB.methodA()
+com.example.api.ClassB.methodA()
 
-//System.out.println is permitted
+// System.out.printlnを許可する
 java.io.PrintStream

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/spotbugs/published-config/production/ExampleOpenApi.config
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/spotbugs/published-config/production/ExampleOpenApi.config
@@ -1,9 +1,9 @@
-// コンストラクタを許可する
+// Constructors are permitted
 com.example.api.ClassA.ClassA()
 com.example.api.ClassB.ClassB()
 com.example.api.ClassC.ClassC()
 
 com.example.api.ClassB.methodA()
 
-// System.out.printlnを許可する
+// System.out.println is permitted
 java.io.PrintStream

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ClassC.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ClassC.java
@@ -1,5 +1,0 @@
-package com.example;
-
-public class ClassC extends ClassB {
-
-}

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ComparingStringsWithEq.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ComparingStringsWithEq.java
@@ -1,0 +1,13 @@
+package com.example;
+
+/**
+ * ES_COMPARING_STRINGS_WITH_EQ のコード例です。
+ */
+public class ComparingStringsWithEq {
+
+    public boolean example() {
+        String value1 = "a";
+        String value2 = "b";
+        return value1 == value2;
+    }
+}

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ComparingStringsWithEq.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ComparingStringsWithEq.java
@@ -1,7 +1,7 @@
 package com.example;
 
 /**
- * ES_COMPARING_STRINGS_WITH_EQ のコード例です。
+ * Example of ES_COMPARING_STRINGS_WITH_EQ code.
  */
 public class ComparingStringsWithEq {
 

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassA.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassA.java
@@ -1,7 +1,7 @@
 package com.example.api;
 
 /**
- * 使用不許可APIチェックのコード例です。
+ * Example of Unauthorized API check code.
  */
 public class ClassA {
 

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassA.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassA.java
@@ -1,5 +1,8 @@
-package com.example;
+package com.example.api;
 
+/**
+ * 使用不許可APIチェックのコード例です。
+ */
 public class ClassA {
 
     public void methodA() {

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassABCExample.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassABCExample.java
@@ -1,7 +1,7 @@
 package com.example.api;
 
 /**
- * 使用不許可APIチェックのコード例です。
+ * Example of Unauthorized API check code.
  */
 public class ClassABCExample {
 

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassABCExample.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassABCExample.java
@@ -1,5 +1,8 @@
-package com.example;
+package com.example.api;
 
+/**
+ * 使用不許可APIチェックのコード例です。
+ */
 public class ClassABCExample {
 
     public void run() {

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassB.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassB.java
@@ -1,5 +1,8 @@
-package com.example;
+package com.example.api;
 
+/**
+ * 使用不許可APIチェックのコード例です。
+ */
 public class ClassB extends ClassA {
 
     @Override

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassB.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassB.java
@@ -1,7 +1,7 @@
 package com.example.api;
 
 /**
- * 使用不許可APIチェックのコード例です。
+ * Example of Unauthorized API check code.
  */
 public class ClassB extends ClassA {
 

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassC.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassC.java
@@ -1,0 +1,8 @@
+package com.example.api;
+
+/**
+ * 使用不許可APIチェックのコード例です。
+ */
+public class ClassC extends ClassB {
+
+}

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassC.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassC.java
@@ -1,7 +1,7 @@
 package com.example.api;
 
 /**
- * 使用不許可APIチェックのコード例です。
+ * Example of Unauthorized API check code.
  */
 public class ClassC extends ClassB {
 

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/secure/PredictableRandom.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/secure/PredictableRandom.java
@@ -3,7 +3,7 @@ package com.example.secure;
 import java.util.Random;
 
 /**
- * PREDICTABLE_RANDOM のコード例です。
+ * Example of PREDICTABLE_RANDOM code.
  */
 public class PredictableRandom {
 

--- a/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/secure/PredictableRandom.java
+++ b/en/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/secure/PredictableRandom.java
@@ -1,8 +1,12 @@
-package com.example;
+package com.example.secure;
 
 import java.util.Random;
 
-public class ClassD {
+/**
+ * PREDICTABLE_RANDOM のコード例です。
+ */
+public class PredictableRandom {
+
     String generateSecretToken() {
         Random r = new Random();
         return Long.toHexString(r.nextLong());

--- a/java/staticanalysis/spotbugs/docs/Maven-settings.md
+++ b/java/staticanalysis/spotbugs/docs/Maven-settings.md
@@ -2,7 +2,7 @@
 
 この文書ではMavenでSpotBugsの実行をするための設定方法と実行方法をガイドします。
 
-なお、この文書の内容はMaven 3.6.3で動作検証を行っています。
+なお、この文書の内容はMaven 3.9.2で動作検証を行っています。
 
 ## チェックを除外するフィルターファイルを配置する
 
@@ -29,14 +29,7 @@
 <plugin>
   <groupId>com.github.spotbugs</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
-  <version>4.5.0.0</version>
-  <dependencies>
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs</artifactId>
-      <version>4.5.0</version>
-    </dependency>
-  </dependencies>
+  <version>4.7.3.4</version>
   <configuration>
     <xmlOutput>true</xmlOutput>
     <!-- チェックを除外するフィルターファイル -->
@@ -87,17 +80,15 @@ mvn compile
 もしチェック違反がある場合は次のように指摘内容がコンソールに出力されます。
 
 ```
-[INFO] --- spotbugs-maven-plugin:4.5.0.0:check (default-cli) @ spotbugs-example ---
 [INFO] BugInstance size is 1
 [INFO] Error size is 0
 [INFO] Total bugs: 1
-[INFO] String オブジェクトを == や != を使用して比較しています。com.example.App.main(String[]) [com.example.App] 該当箇所 App.java:[line 9] ES_COMPARING_STRINGS_WITH_EQ
+[ERROR] Medium: String オブジェクトを == や != を使用して比較しています。com.example.ComparingStringsWithEq.example() [com.example.ComparingStringsWithEq] 該当箇所 ComparingStringsWithEq.java:[line 11] ES_COMPARING_STRINGS_WITH_EQ
 ```
 
 すべてのチェックをパスした場合は次のようにコンソールに出力されます。
 
 ```
-[INFO] --- spotbugs-maven-plugin:4.5.0.0:check (default-cli) @ spotbugs-example ---
 [INFO] BugInstance size is 0
 [INFO] Error size is 0
 [INFO] No errors/warnings found

--- a/java/staticanalysis/spotbugs/docs/find-sec-bugs.md
+++ b/java/staticanalysis/spotbugs/docs/find-sec-bugs.md
@@ -13,7 +13,7 @@ Find Security BugsはSpotBugsのプラグインです。
 <plugin>
   <groupId>com.github.spotbugs</groupId>
   <artifactId>spotbugs-maven-plugin</artifactId>
-  <version>4.5.0.0</version>
+  <version>4.7.3.4</version>
   <!-- 中略 -->
   <configuration>
     <!-- 中略 -->
@@ -27,7 +27,7 @@ Find Security BugsはSpotBugsのプラグインです。
       <plugin>
         <groupId>com.h3xstream.findsecbugs</groupId>
         <artifactId>findsecbugs-plugin</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.0</version>
       </plugin>
     </plugins>
   </configuration>

--- a/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
+++ b/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
@@ -16,28 +16,12 @@
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.5.0.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs</artifactId>
-            <version>4.5.0</version>
-          </dependency>
-        </dependencies>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <!-- チェックを除外するフィルターファイル -->

--- a/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
+++ b/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
@@ -21,7 +21,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.5.0.0</version>
+        <version>4.7.3.4</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <!-- チェックを除外するフィルターファイル -->
@@ -39,7 +39,7 @@
             <plugin>
               <groupId>com.h3xstream.findsecbugs</groupId>
               <artifactId>findsecbugs-plugin</artifactId>
-              <version>1.11.0</version>
+              <version>1.12.0</version>
             </plugin>
           </plugins>
         </configuration>

--- a/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
+++ b/java/staticanalysis/spotbugs/spotbugs-example/pom.xml
@@ -12,8 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <build>

--- a/java/staticanalysis/spotbugs/spotbugs-example/spotbugs/published-config/production/ExampleOpenApi.config
+++ b/java/staticanalysis/spotbugs/spotbugs-example/spotbugs/published-config/production/ExampleOpenApi.config
@@ -1,9 +1,9 @@
-//コンストラクタを許可する
-com.example.ClassA.ClassA()
-com.example.ClassB.ClassB()
-com.example.ClassC.ClassC()
+// コンストラクタを許可する
+com.example.api.ClassA.ClassA()
+com.example.api.ClassB.ClassB()
+com.example.api.ClassC.ClassC()
 
-com.example.ClassB.methodA()
+com.example.api.ClassB.methodA()
 
-//System.out.printlnを許可する
+// System.out.printlnを許可する
 java.io.PrintStream

--- a/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ClassC.java
+++ b/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ClassC.java
@@ -1,5 +1,0 @@
-package com.example;
-
-public class ClassC extends ClassB {
-
-}

--- a/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ComparingStringsWithEq.java
+++ b/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/ComparingStringsWithEq.java
@@ -1,0 +1,13 @@
+package com.example;
+
+/**
+ * ES_COMPARING_STRINGS_WITH_EQ のコード例です。
+ */
+public class ComparingStringsWithEq {
+
+    public boolean example() {
+        String value1 = "a";
+        String value2 = "b";
+        return value1 == value2;
+    }
+}

--- a/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassA.java
+++ b/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassA.java
@@ -1,5 +1,8 @@
-package com.example;
+package com.example.api;
 
+/**
+ * 使用不許可APIチェックのコード例です。
+ */
 public class ClassA {
 
     public void methodA() {

--- a/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassABCExample.java
+++ b/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassABCExample.java
@@ -1,5 +1,8 @@
-package com.example;
+package com.example.api;
 
+/**
+ * 使用不許可APIチェックのコード例です。
+ */
 public class ClassABCExample {
 
     public void run() {

--- a/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassB.java
+++ b/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassB.java
@@ -1,5 +1,8 @@
-package com.example;
+package com.example.api;
 
+/**
+ * 使用不許可APIチェックのコード例です。
+ */
 public class ClassB extends ClassA {
 
     @Override

--- a/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassC.java
+++ b/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/api/ClassC.java
@@ -1,0 +1,8 @@
+package com.example.api;
+
+/**
+ * 使用不許可APIチェックのコード例です。
+ */
+public class ClassC extends ClassB {
+
+}

--- a/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/secure/PredictableRandom.java
+++ b/java/staticanalysis/spotbugs/spotbugs-example/src/main/java/com/example/secure/PredictableRandom.java
@@ -1,8 +1,12 @@
-package com.example;
+package com.example.secure;
 
 import java.util.Random;
 
-public class ClassD {
+/**
+ * PREDICTABLE_RANDOM のコード例です。
+ */
+public class PredictableRandom {
+
     String generateSecretToken() {
         Random r = new Random();
         return Long.toHexString(r.nextLong());


### PR DESCRIPTION
以下の対応を実施しています。

- ドキュメントの修正
  - `spotbugs-example`の修正内容を反映
  - 検証に使用するMavenのバージョンを最新化
- `spotbugs-example`の修正
  - SpotBugsのバージョンを最新化
  - FindSecureBugsのバージョンを最新化
  - Javaバージョンを17に変更
  - 不要な依存関係を削除
  - サンプルコードを追加
  - 既存サンプルコードを理解しやすくするため構造を見直し
  - 英語版に`.gitignore`が配置されていなかったので追加

Jenkins上での実行方法についても見直しが必要ですが、現時点では対応していません。