### PR TITLE
「MavenでのArchUnitの実行方法」に「チェックを除外するフィルターファイルを配置する」方法を記載（英）

### DIFF
--- a/en/java/staticanalysis/archunit/docs/Maven-settings.md
+++ b/en/java/staticanalysis/archunit/docs/Maven-settings.md
@@ -4,6 +4,10 @@ ArchUnit can be run as a JUnit test by running the `mvn test`.
 
 ## Place a filter file to exclude checks
 
+If want to exclude the test target by using the exclusion setting file, refer to [here](Ops-Rule.md#exclude-it-from-all-architecture-tests-by-including-it-in-the-exclusion-configuration-file).
+
+If do not want to use the exclusion setting file, please go to the next step.
+
 ## Include ArchUnit dependencies
 
 Edit `pom.xml` to add ArchUnit as a dependency.


### PR DESCRIPTION
https://github.com/Fintan-contents/nablarch-system-development-guide/pull/168 の対応を実施する中で、 ae1089806535b9695d4c10c14b351b37b003f8d4 で追加されたフィルターファイルの配置方法が英語版に反映されていなかったことを検知したため、追加した。

修正内容は、[システム開発ガイド中のスタイルガイドの記載](https://github.com/Fintan-contents/nablarch-system-development-guide/blob/master/en/Sample_Project/Sample_Project_Development_Guide/PGUT_Phase/proman-style-guide/java/staticanalysis/archunit/docs/Maven-settings.md)を参考にした。